### PR TITLE
More friendly mutable interface

### DIFF
--- a/repa-array/Data/Repa/Array/Delayed.hs
+++ b/repa-array/Data/Repa/Array/Delayed.hs
@@ -11,6 +11,7 @@ import Data.Repa.Array.Index
 import Data.Repa.Array.Internals.Bulk
 import Data.Repa.Array.Internals.Load
 import Data.Repa.Array.Internals.Target
+import Control.Monad.Primitive
 import Debug.Trace
 import GHC.Exts
 import qualified Data.Repa.Eval.Generic.Par       as Par
@@ -74,8 +75,8 @@ instance (Layout l1, Target l2 a)
   = do  let !(I# len)   = size (extent l1)
         let write ix x  = unsafeWriteBuffer buf (I# ix) x
         let get' ix     = get $ fromIndex   l1  (I# ix)
-        Seq.fillLinear  write get' len
-        touchBuffer  buf
+        Seq.fillLinear write get' len
+        touchBuffer buf
  {-# INLINE_ARRAY loadS #-}
 
  loadP gang (ADelayed l1 get) !buf

--- a/repa-array/Data/Repa/Array/Delayed.hs
+++ b/repa-array/Data/Repa/Array/Delayed.hs
@@ -13,8 +13,8 @@ import Data.Repa.Array.Internals.Load
 import Data.Repa.Array.Internals.Target
 import Debug.Trace
 import GHC.Exts
-import qualified Data.Array.Repa.Eval.Par       as Par
-import qualified Data.Array.Repa.Eval.Seq       as Seq
+import qualified Data.Repa.Eval.Generic.Par       as Par
+import qualified Data.Repa.Eval.Generic.Seq       as Seq
 import Prelude hiding (map, zipWith)
 #include "repa-array.h"
 
@@ -23,10 +23,10 @@ import Prelude hiding (map, zipWith)
 -- | Delayed arrays wrap functions from an index to element value.
 --   The index space is specified by an inner layout, @l@.
 --
---   Every time you index into a delayed array the element at that position 
+--   Every time you index into a delayed array the element at that position
 --   is recomputed.
-data D l 
-        = Delayed 
+data D l
+        = Delayed
         { delayedLayout :: l }
 
 deriving instance Eq   l => Eq   (D l)
@@ -57,7 +57,7 @@ deriving instance Show (Name l) => Show (Name (D l))
 -- | Delayed arrays.
 instance Layout l => Bulk (D l) a where
  data Array (D l) a
-        = ADelayed !l (Index l -> a) 
+        = ADelayed !l (Index l -> a)
 
  layout (ADelayed l _)      = Delayed l
  {-# INLINE_ARRAY layout #-}
@@ -83,7 +83,7 @@ instance (Layout l1, Target l2 a)
         let !(I# len)   = size (extent l1)
         let write ix x  = unsafeWriteBuffer buf (I# ix) x
         let get' ix     = get $ fromIndex   l1  (I# ix)
-        Par.fillChunked gang write get' len 
+        Par.fillChunked gang write get' len
         touchBuffer  buf
         traceEventIO "Repa.loadP[Delayed]: end"
  {-# INLINE_ARRAY loadP #-}
@@ -94,10 +94,10 @@ instance (Layout l1, Target l2 a)
 --
 --  @> toList $ fromFunction (Linear 10) (* 2)
 --    = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]@
--- 
+--
 fromFunction :: l -> (Index l -> a) -> Array (D l) a
-fromFunction l f 
-        = ADelayed l f 
+fromFunction l f
+        = ADelayed l f
 {-# INLINE_ARRAY fromFunction #-}
 
 
@@ -118,7 +118,7 @@ delay arr = map id arr
 {-# INLINE delay #-}
 
 
--- | Apply a worker function to each element of an array, 
+-- | Apply a worker function to each element of an array,
 --   yielding a new array with the same extent.
 map     :: Bulk l a
         => (a -> b) -> Array l a -> Array (D l) b
@@ -138,9 +138,9 @@ zipWith :: (Bulk l1 a, Bulk l2 b, Index l1 ~ Index l2)
         -> Array (D (Index l1))  sh c
 
 zipWith f arr1 arr2
- = fromFunction (intersectDim (extent arr1) (extent arr2)) 
+ = fromFunction (intersectDim (extent arr1) (extent arr2))
                 get_zipWith
- where  get_zipWith ix  
+ where  get_zipWith ix
          = f (arr1 `index` ix) (arr2 `index` ix)
         {-# INLINE get_zipWith #-}
 {-# INLINE_ARRAY zipWith #-}

--- a/repa-array/Data/Repa/Array/Internals/Load.hs
+++ b/repa-array/Data/Repa/Array/Internals/Load.hs
@@ -5,6 +5,7 @@ where
 import Data.Repa.Array.Internals.Target
 import Data.Repa.Array.Internals.Bulk
 import Data.Repa.Eval.Gang
+import Control.Monad.Primitive
 
 
 -- | Compute all elements defined by a delayed array and write them to a
@@ -14,12 +15,12 @@ import Data.Repa.Eval.Gang
 --   representation. If you want to use a pre-existing manifest array as the
 --   source then `delay` it first.
 --
-class (Bulk lSrc a, Target lDst a) => Load lSrc lDst a where
+class (Bulk l1 a, Target l2 a) => Load l1 l2 a where
 
  -- | Fill an entire array sequentially.
- loadS          :: Array lSrc a -> Buffer lDst a -> IO ()
+ loadS          :: Array l1 a -> IOBuffer l2 a -> IO ()
 
  -- | Fill an entire array in parallel.
  loadP          :: Gang
-                -> Array lSrc a -> Buffer lDst a -> IO ()
+                -> Array l1 a -> IOBuffer l2 a -> IO ()
 

--- a/repa-array/Data/Repa/Array/Internals/Load.hs
+++ b/repa-array/Data/Repa/Array/Internals/Load.hs
@@ -4,12 +4,12 @@ module Data.Repa.Array.Internals.Load
 where
 import Data.Repa.Array.Internals.Target
 import Data.Repa.Array.Internals.Bulk
-import Data.Array.Repa.Eval.Gang
+import Data.Repa.Eval.Gang
 
 
 -- | Compute all elements defined by a delayed array and write them to a
 --   manifest target representation.
---  
+--
 --   The instances of this class require that the source array has a delayed
 --   representation. If you want to use a pre-existing manifest array as the
 --   source then `delay` it first.
@@ -20,6 +20,6 @@ class (Bulk lSrc a, Target lDst a) => Load lSrc lDst a where
  loadS          :: Array lSrc a -> Buffer lDst a -> IO ()
 
  -- | Fill an entire array in parallel.
- loadP          :: Gang 
+ loadP          :: Gang
                 -> Array lSrc a -> Buffer lDst a -> IO ()
 

--- a/repa-array/Data/Repa/Array/Internals/Operator/Fold.hs
+++ b/repa-array/Data/Repa/Array/Internals/Operator/Fold.hs
@@ -20,7 +20,7 @@ import System.IO.Unsafe
 --
 --   * The total lengths of all segments need not match the length of the
 --     input elements vector. The returned `C.Folds` state can be inspected
---     to determine whether all segments were completely folded, or the 
+--     to determine whether all segments were completely folded, or the
 --     vector of segment lengths or elements was too short relative to the
 --     other.
 --
@@ -59,7 +59,7 @@ folds nGrp nRes f z vLens vVals
 -- [("white",106),("red",15),("green",45)]
 -- @
 --
-foldsWith   
+foldsWith
         :: FoldsDict lSeg lElt lGrp tGrp lRes tRes n a b
         => Name lGrp             -- ^ Layout for group names.
         -> Name lRes             -- ^ Layout for fold results.
@@ -72,7 +72,7 @@ foldsWith
 
 foldsWith nGrp nRes f z s0 vLens vVals
  = unsafePerformIO
- $ do   
+ $ do
         let f' !x !y = return $ f x y
             {-# INLINE f' #-}
 
@@ -91,8 +91,8 @@ foldsWith nGrp nRes f z s0 vLens vVals
 type FoldsDict lSeg lElt lGrp tGrp lRes tRes n a b
       = ( Bulk   lSeg (n, Int)
         , Bulk   lElt a
-        , Target lGrp n 
+        , Target lGrp n
         , Target lRes b
         , Index  lGrp ~ Index lRes
-        , Unpack (Buffer lGrp n) tGrp
-        , Unpack (Buffer lRes b) tRes)
+        , Unpack (IOBuffer lGrp n) tGrp
+        , Unpack (IOBuffer lRes b) tRes)

--- a/repa-array/Data/Repa/Array/Internals/Operator/Group.hs
+++ b/repa-array/Data/Repa/Array/Internals/Operator/Group.hs
@@ -36,17 +36,17 @@ groups nGrp nLen arr
 
 
 -- | Like `groups`, but use the given function to determine whether two
---   consecutive elements should be in the same group. Also take 
+--   consecutive elements should be in the same group. Also take
 --   an initial starting group and count.
 --
--- @ 
+-- @
 -- > import Data.Repa.Array.Material
 -- > import Data.Repa.Nice
 -- > nice $ groupsWith U U (==) (Just ('w', 5)) (fromList U "waaabllle")
 -- ([('w',6),('a',3),('b',1),('l',3)],Just ('e',1))
 -- @
 --
-groupsWith 
+groupsWith
         :: GroupsDict lElt lGrp tGrp lLen tLen n
         => Name lGrp           -- ^ Layout for group names.
         -> Name lLen           -- ^ Layour for group lengths.
@@ -57,14 +57,14 @@ groupsWith
 
 groupsWith nGrp nLen f !c !vec0
  = (vec1, snd k1)
- where  
+ where
         f' x y  = return $ f x y
         {-# INLINE f' #-}
 
         (vec1, k1)
          = A.unchainToArray (T2 nGrp nLen)
          $ C.liftChain
-         $ C.groupsByC f' c  
+         $ C.groupsByC f' c
          $ A.chainOfArray vec0
 {-# INLINE_ARRAY groupsWith #-}
 
@@ -73,9 +73,9 @@ groupsWith nGrp nLen f !c !vec0
 type GroupsDict  lElt lGrp tGrp lLen tLen n
       = ( Bulk   lElt n
         , Target lGrp n
-        , Target lLen Int 
+        , Target lLen Int
         , Index  lGrp ~ Index lLen
-        , Unpack (Buffer lLen Int) tLen
-        , Unpack (Buffer lGrp n)   tGrp)
+        , Unpack (IOBuffer lLen Int) tLen
+        , Unpack (IOBuffer lGrp n)   tGrp)
 
-      
+

--- a/repa-array/Data/Repa/Array/Material/Boxed.hs
+++ b/repa-array/Data/Repa/Array/Material/Boxed.hs
@@ -25,11 +25,8 @@ import qualified Data.Vector.Mutable                    as VM
 --   UNSAFE: Indexing into raw material arrays is not bounds checked.
 --   You may want to wrap this with a Checked layout as well.
 --
-data B  = Boxed { boxedLength :: Int}
-
-deriving instance Eq B
-deriving instance Show B
-
+newtype B = Boxed { boxedLength :: Int }
+  deriving (Show, Eq)
 
 ------------------------------------------------------------------------------
 -- | Boxed arrays.
@@ -54,7 +51,7 @@ deriving instance Show (Name B)
 ------------------------------------------------------------------------------
 -- | Boxed arrays.
 instance Bulk B a where
- data Array B a                  = BArray (V.Vector a)
+ newtype Array B a               = BArray (V.Vector a)
  layout (BArray vec)             = Boxed (V.length vec)
  index  (BArray vec) ix          = V.unsafeIndex vec ix
  {-# INLINE_ARRAY layout  #-}
@@ -74,35 +71,45 @@ instance Windowable B a where
 -------------------------------------------------------------------------------
 -- | Boxed buffers.
 instance Target B a where
- data Buffer B a
-  = BBuffer !(VM.IOVector a)
+ newtype Buffer s B a
+  = BBuffer (VM.MVector s a)
 
  unsafeNewBuffer (Boxed len)
   = liftM BBuffer (VM.unsafeNew len)
  {-# INLINE_ARRAY unsafeNewBuffer #-}
+
+ unsafeReadBuffer (BBuffer mvec) ix
+  = VM.unsafeRead mvec ix
+ {-# INLINE_ARRAY unsafeReadBuffer #-}
 
  unsafeWriteBuffer (BBuffer mvec) ix
   = VM.unsafeWrite mvec ix
  {-# INLINE_ARRAY unsafeWriteBuffer #-}
 
  unsafeGrowBuffer (BBuffer mvec) bump
-  = do  mvec'   <- VM.unsafeGrow mvec bump
-        return  $ BBuffer mvec'
+  = liftM BBuffer (VM.unsafeGrow mvec bump)
  {-# INLINE_ARRAY unsafeGrowBuffer #-}
 
- unsafeFreezeBuffer (BBuffer mvec)     
-  = do  vec     <- V.unsafeFreeze mvec
-        return  $  BArray vec
+ unsafeFreezeBuffer (BBuffer mvec)
+  = liftM BArray (V.unsafeFreeze mvec)
  {-# INLINE_ARRAY unsafeFreezeBuffer #-}
 
+ unsafeThawBuffer (BArray vec)
+  = liftM BBuffer (V.unsafeThaw vec)
+ {-# INLINE_ARRAY unsafeThawBuffer #-}
+
  unsafeSliceBuffer start len (BBuffer mvec)
-  = do  let mvec'  = VM.unsafeSlice start len mvec
-        return $ BBuffer mvec'
+  = let mvec'  = VM.unsafeSlice start len mvec
+    in  return $ BBuffer mvec'
  {-# INLINE_ARRAY unsafeSliceBuffer #-}
 
- touchBuffer _ 
+ touchBuffer _
   = return ()
  {-# INLINE_ARRAY touchBuffer #-}
+
+ bufferLayout (BBuffer mvec)
+  = Boxed (VM.length mvec)
+ {-# INLINE_ARRAY bufferLayout #-}
 
  {-# SPECIALIZE instance Target B Int    #-}
  {-# SPECIALIZE instance Target B Float  #-}
@@ -113,9 +120,9 @@ instance Target B a where
  {-# SPECIALIZE instance Target B Word64 #-}
 
 
-instance Unpack (Buffer B a) (VM.IOVector a) where
- unpack (BBuffer vec)  = vec `seq` vec
- repack !_ !vec        = BBuffer vec
+instance Unpack (Buffer s B a) (VM.MVector s a) where
+ unpack (BBuffer vec) = vec
+ repack _ vec         = BBuffer vec
  {-# INLINE_ARRAY unpack #-}
  {-# INLINE_ARRAY repack #-}
 

--- a/repa-array/Data/Repa/Array/Material/Foreign.hs
+++ b/repa-array/Data/Repa/Array/Material/Foreign.hs
@@ -1,13 +1,13 @@
-{-# OPTIONS -fno-warn-orphans #-}
+{-# LANGUAGE ViewPatterns #-}
 module Data.Repa.Array.Material.Foreign
-        ( F      (..)
-        , Name   (..)
-        , Array  (..)
-        , Buffer (..)
+  ( F      (..)
+  , Name   (..)
+  , Array  (..)
+  , Buffer (..)
 
-          -- * Conversions
-        , fromForeignPtr,       toForeignPtr
-        , fromByteString,       toByteString)
+  -- * Conversions
+  , fromForeignPtr,       toForeignPtr
+  , fromByteString,       toByteString)
 where
 import Data.Repa.Array.Delayed
 import Data.Repa.Array.Window
@@ -15,18 +15,18 @@ import Data.Repa.Array.Index
 import Data.Repa.Array.Internals.Target
 import Data.Repa.Array.Internals.Bulk
 import Data.Word
-import Control.Monad.Primitive
-import Foreign.Ptr
 import Foreign.ForeignPtr
 import Foreign.Storable
-import Foreign.Marshal.Alloc
-import Foreign.Marshal.Utils
-import System.IO.Unsafe
 import Data.Repa.Fusion.Unpack
 import Data.ByteString                                  (ByteString)
-import qualified Foreign.ForeignPtr.Unsafe              as Unsafe
 import qualified Data.ByteString.Internal               as BS
-import GHC.Exts
+import Control.Monad
+
+import qualified Data.Vector.Storable as S
+import qualified Data.Vector.Storable.Mutable as M
+
+import Control.Monad.Primitive
+
 #include "repa-array.h"
 
 
@@ -41,229 +41,115 @@ newtype F = Foreign { foreignLength :: Int }
 ------------------------------------------------------------------------------
 -- | Foreign arrays.
 instance Layout F where
- data Name  F            = F
- type Index F            = Int
- name                    = F
- create F len            = Foreign len
- extent (Foreign len)    = len
- toIndex   _ ix          = ix
- fromIndex _ ix          = ix
- {-# INLINE_ARRAY name      #-}
- {-# INLINE_ARRAY create    #-}
- {-# INLINE_ARRAY extent    #-}
- {-# INLINE_ARRAY toIndex   #-}
- {-# INLINE_ARRAY fromIndex #-}
+  data Name  F            = F
+  type Index F            = Int
+  name                    = F
+  create F len            = Foreign len
+  extent (Foreign len)    = len
+  toIndex   _ ix          = ix
+  fromIndex _ ix          = ix
+  {-# INLINE_ARRAY name      #-}
+  {-# INLINE_ARRAY create    #-}
+  {-# INLINE_ARRAY extent    #-}
+  {-# INLINE_ARRAY toIndex   #-}
+  {-# INLINE_ARRAY fromIndex #-}
 
 deriving instance Eq   (Name F)
 deriving instance Show (Name F)
 
-
 -------------------------------------------------------------------------------
 -- | Foreign arrays.
 instance Storable a => Bulk F a where
- data Array F  a          = FArray !Int !Int !(ForeignPtr a)
- layout (FArray _  len _) = Foreign len
- index  (FArray st len fptr) ix
-        = BS.inlinePerformIO
-        $ withForeignPtr fptr
-        $ \ptr -> peekElemOff ptr (st + toIndex (Foreign len) ix)
- {-# INLINE_ARRAY layout #-}
- {-# INLINE_ARRAY index  #-}
- {-# SPECIALIZE instance Bulk F Char    #-}
- {-# SPECIALIZE instance Bulk F Int     #-}
- {-# SPECIALIZE instance Bulk F Float   #-}
- {-# SPECIALIZE instance Bulk F Double  #-}
- {-# SPECIALIZE instance Bulk F Word8   #-}
- {-# SPECIALIZE instance Bulk F Word16  #-}
- {-# SPECIALIZE instance Bulk F Word32  #-}
- {-# SPECIALIZE instance Bulk F Word64  #-}
+  newtype Array F a   = FArray (S.Vector a)
+  layout (FArray v)   = Foreign (S.length v)
+  index  (FArray v) i = S.unsafeIndex v i
+  {-# INLINE_ARRAY layout #-}
+  {-# INLINE_ARRAY index  #-}
+  {-# SPECIALIZE instance Bulk F Char    #-}
+  {-# SPECIALIZE instance Bulk F Int     #-}
+  {-# SPECIALIZE instance Bulk F Float   #-}
+  {-# SPECIALIZE instance Bulk F Double  #-}
+  {-# SPECIALIZE instance Bulk F Word8   #-}
+  {-# SPECIALIZE instance Bulk F Word16  #-}
+  {-# SPECIALIZE instance Bulk F Word32  #-}
+  {-# SPECIALIZE instance Bulk F Word64  #-}
 
-deriving instance Show a => Show (Array F a)
+deriving instance (S.Storable a, Show a) => Show (Array F a)
 
-
--- | Foreign arrays
-{-
-instance Unpack (Array F a) (Int, Int, ForeignPtr a) where
- unpack (FArray st len fptr)    = (st, len, fptr)
- repack _ (st, len, fptr)       = FArray st len fptr
+instance Unpack (Array F a) (S.Vector a) where
+ unpack (FArray v) = v
+ repack _ v        = FArray v
  {-# INLINE_ARRAY unpack #-}
  {-# INLINE_ARRAY repack #-}
--}
-data FArrayUnpacked a
-        = FArrayUnpacked Int# Int# !(ForeignPtr a)
-
-
-instance Unpack (Array F a) (FArrayUnpacked a) where
- unpack (FArray (I# st) (I# len) fptr)    = FArrayUnpacked st len fptr
- repack _ (FArrayUnpacked st len fptr)    = FArray (I# st) (I# len) fptr
- {-# INLINE_ARRAY unpack #-}
- {-# INLINE_ARRAY repack #-}
-
 
 -------------------------------------------------------------------------------
 -- | Windowing Foreign arrays.
 instance Storable a => Windowable F a where
- window st' len' (FArray st _len fptr)
-        = FArray (st + st') len' fptr
- {-# INLINE_ARRAY window #-}
- {-# SPECIALIZE instance Windowable F Char    #-}
- {-# SPECIALIZE instance Windowable F Int     #-}
- {-# SPECIALIZE instance Windowable F Float   #-}
- {-# SPECIALIZE instance Windowable F Double  #-}
- {-# SPECIALIZE instance Windowable F Word8   #-}
- {-# SPECIALIZE instance Windowable F Word16  #-}
- {-# SPECIALIZE instance Windowable F Word32  #-}
- {-# SPECIALIZE instance Windowable F Word64  #-}
+  window st len (FArray vec)
+         = FArray (S.slice st len vec)
+  {-# INLINE_ARRAY window #-}
+  {-# SPECIALIZE instance Windowable F Char    #-}
+  {-# SPECIALIZE instance Windowable F Int     #-}
+  {-# SPECIALIZE instance Windowable F Float   #-}
+  {-# SPECIALIZE instance Windowable F Double  #-}
+  {-# SPECIALIZE instance Windowable F Word8   #-}
+  {-# SPECIALIZE instance Windowable F Word16  #-}
+  {-# SPECIALIZE instance Windowable F Word32  #-}
+  {-# SPECIALIZE instance Windowable F Word64  #-}
 
 
 -------------------------------------------------------------------------------
 -- | Foreign buffers
+
 instance Storable a => Target F a where
- data Buffer s F a
-        = FBuffer
-                !Int            -- starting position of data, in elements.
-                !Int            -- length of buffer, in elements.
-                !(ForeignPtr a) -- element data.
+  newtype Buffer s F a = FBuffer (M.MVector s a)
 
- unsafeNewBuffer (Foreign len)
-  = unsafePrimToPrim $
-    do  let (proxy :: a) = undefined
-        ptr     <- mallocBytes (sizeOf proxy * len)
-        _       <- peek ptr  `asTypeOf` return proxy
-
-        fptr    <- newForeignPtr finalizerFree ptr
-        return  $ FBuffer 0 len fptr
- {-# INLINE_ARRAY unsafeNewBuffer #-}
-
- -- CAREFUL: Unwrapping the foreignPtr like this means we need to be careful
- -- to touch it after the last use, otherwise the finaliser might run too early.
- unsafeWriteBuffer (FBuffer start _ fptr) !ix !x
-  = unsafePrimToPrim $
-    pokeElemOff (Unsafe.unsafeForeignPtrToPtr fptr) (start + ix) x
- {-# INLINE_ARRAY unsafeWriteBuffer #-}
-
- unsafeGrowBuffer (FBuffer start len fptr) bump
-  = unsafePrimToPrim $ withForeignPtr fptr $ \ptr
-  -> do let (proxy :: a) = undefined
-        let len'         = len + bump
-        let bytesLen'    = sizeOf proxy * len'
-        let bytesStart   = sizeOf proxy * start
-
-        ptr'            <- mallocBytes bytesLen'
-        copyBytes ptr' (plusPtr ptr bytesStart) len
-
-        fptr'   <- newForeignPtr finalizerFree ptr'
-        return  $ FBuffer 0 len' fptr'
- {-# INLINE_ARRAY unsafeGrowBuffer #-}
-
- unsafeFreezeBuffer (FBuffer start len fptr)
-  =     return  $ FArray start len fptr
- {-# INLINE_ARRAY unsafeFreezeBuffer #-}
-
- unsafeSliceBuffer start' len' (FBuffer start _len fptr)
-  =     return  $ FBuffer (start + start') len' fptr
- {-# INLINE_ARRAY unsafeSliceBuffer #-}
-
- touchBuffer (FBuffer _ _ fptr)
-  = unsafePrimToPrim $ touchForeignPtr fptr
- {-# INLINE_ARRAY touchBuffer #-}
-
- bufferLayout (FBuffer _ len _)
-   = Foreign len
- {-# INLINE_ARRAY bufferLayout #-}
-
- {-# SPECIALIZE instance Target F Char   #-}
- {-# SPECIALIZE instance Target F Int    #-}
- {-# SPECIALIZE instance Target F Float  #-}
- {-# SPECIALIZE instance Target F Double #-}
- {-# SPECIALIZE instance Target F Word8  #-}
- {-# SPECIALIZE instance Target F Word16 #-}
- {-# SPECIALIZE instance Target F Word32 #-}
- {-# SPECIALIZE instance Target F Word64 #-}
-
+  unsafeNewBuffer (Foreign n)           = FBuffer `liftM` M.unsafeNew n
+  unsafeReadBuffer (FBuffer mv) i       = M.unsafeRead mv i
+  unsafeWriteBuffer (FBuffer mv) i a    = M.unsafeWrite mv i a
+  unsafeGrowBuffer (FBuffer mv) x       = FBuffer `liftM` M.unsafeGrow mv x
+  unsafeThawBuffer (FArray v)           = FBuffer `liftM` S.unsafeThaw v
+  unsafeFreezeBuffer (FBuffer mv)       = FArray `liftM` S.unsafeFreeze mv
+  unsafeSliceBuffer i n (FBuffer mv)    = return $ FBuffer (M.unsafeSlice i n mv)
+  touchBuffer (FBuffer (M.MVector _ p)) = unsafePrimToPrim $ touchForeignPtr p
+  bufferLayout (FBuffer mv)             = Foreign $ M.length mv
+  {-# INLINE unsafeNewBuffer    #-}
+  {-# INLINE unsafeWriteBuffer  #-}
+  {-# INLINE unsafeReadBuffer   #-}
+  {-# INLINE unsafeGrowBuffer   #-}
+  {-# INLINE unsafeThawBuffer   #-}
+  {-# INLINE unsafeFreezeBuffer #-}
+  {-# INLINE unsafeSliceBuffer  #-}
+  {-# INLINE touchBuffer        #-}
+  {-# INLINE bufferLayout       #-}
 
 -- | Unpack Foreign buffers
-instance Unpack (Buffer s F a) (Int, Int, ForeignPtr a) where
- unpack (FBuffer start len fptr)  = (start, len, fptr)
- repack _ (start, len, fptr)      = FBuffer start len fptr
+instance Unpack (Buffer s F a) (M.MVector s a) where
+ unpack (FBuffer mv)  = mv
+ repack _ mv          = FBuffer mv
  {-# INLINE_ARRAY unpack #-}
  {-# INLINE_ARRAY repack #-}
 
-
 -------------------------------------------------------------------------------
 -- | O(1). Wrap a `ForeignPtr` as an array.
-fromForeignPtr :: Int -> ForeignPtr a -> Array F a
-fromForeignPtr !len !fptr
-        = FArray 0 len fptr
+fromForeignPtr :: Storable a => Int -> ForeignPtr a -> Array F a
+fromForeignPtr n p = FArray $ S.unsafeFromForeignPtr p 0 n
 {-# INLINE_ARRAY fromForeignPtr #-}
 
 
--- | O(1). Unpack a `ForeignPtr` from an array.
-toForeignPtr :: Array F a -> ForeignPtr a
-toForeignPtr (FArray _ _ fptr)
-        = fptr
+toForeignPtr :: Storable a => Array F a -> (Int, Int, ForeignPtr a)
+toForeignPtr (FArray (S.unsafeToForeignPtr -> (p,i,n))) = (i,n,p)
 {-# INLINE_ARRAY toForeignPtr #-}
-
 
 -- | O(1). Convert a foreign 'Vector' to a `ByteString`.
 toByteString :: Array F Word8 -> ByteString
-toByteString (FArray start len fptr)
- = BS.PS fptr start len
+toByteString (FArray (S.unsafeToForeignPtr -> (p,i,n)))
+ = BS.PS p i n
 {-# INLINE_ARRAY toByteString #-}
-
 
 -- | O(1). Convert a `ByteString` to an foreign `Vector`.
 fromByteString :: ByteString -> Array F Word8
-fromByteString (BS.PS fptr start len)
- = FArray start len fptr
+fromByteString (BS.PS p i n)
+ = FArray (S.unsafeFromForeignPtr p i n)
 {-# INLINE_ARRAY fromByteString #-}
-
-
--------------------------------------------------------------------------------
--- | Equality of Unsafe Foreign arrays.
-instance Eq (Array F Word8) where
- (==) (FArray start1 len1 fptr1)
-      (FArray start2 len2 fptr2)
-  | len1 == len2
-  =  unsafePerformIO
-  $  withForeignPtr fptr1 $ \ptr1
-  -> withForeignPtr fptr2 $ \ptr2
-  -> do
-        let loop_eq_ArrayF ix
-             | ix >= len1       = return True
-             | otherwise
-             = do x1 <- peekElemOff ptr1 (start1 + ix)
-                  x2 <- peekElemOff ptr2 (start2 + ix)
-                  if x1 == x2
-                   then loop_eq_ArrayF (ix + 1)
-                   else return False
-
-        loop_eq_ArrayF 0
-
-  | otherwise = False
- {-# INLINE_ARRAY (==) #-}
-
-
--- | Equality of Unsafe Foreign arrays.
-instance Eq (Array F Char) where
- (==) (FArray start1 len1 fptr1)
-      (FArray start2 len2 fptr2)
-  |  len1 == len2
-  =  unsafePerformIO
-  $  withForeignPtr fptr1 $ \(ptr1 :: Ptr Char)
-  -> withForeignPtr fptr2 $ \(ptr2 :: Ptr Char)
-  -> do
-        let loop_eq_ArrayF ix
-             | ix >= len1       = return True
-             | otherwise
-             = do x1 <- peekElemOff ptr1 (start1 + ix)
-                  x2 <- peekElemOff ptr2 (start2 + ix)
-                  if x1 == x2
-                   then loop_eq_ArrayF (ix + 1)
-                   else return False
-
-        loop_eq_ArrayF 0
-
-  | otherwise = False
- {-# INLINE_ARRAY (==) #-}
 

--- a/repa-array/Data/Repa/Array/Material/Unboxed.hs
+++ b/repa-array/Data/Repa/Array/Material/Unboxed.hs
@@ -79,7 +79,7 @@ deriving instance (Show a, U.Unbox a) => Show (Array U a)
 
 
 instance Unpack (Array U a) (U.Vector a) where
- unpack (UArray vec)    = vec `seq` vec
+ unpack (UArray vec)    = vec
  repack !_ !vec         = UArray vec
  {-# INLINE_ARRAY unpack #-}
  {-# INLINE_ARRAY repack #-}

--- a/repa-array/Data/Repa/Array/Material/Unboxed.hs
+++ b/repa-array/Data/Repa/Array/Material/Unboxed.hs
@@ -33,11 +33,8 @@ import qualified Data.Vector.Unboxed.Mutable            as UM
 --   UNSAFE: Indexing into raw material arrays is not bounds checked.
 --   You may want to wrap this with a Checked layout as well.
 --
-data U  = Unboxed { unboxedLength :: Int }
-
-deriving instance Eq U
-deriving instance Show U
-
+newtype U = Unboxed { unboxedLength :: Int }
+  deriving (Show, Eq)
 
 -------------------------------------------------------------------------------
 -- | Unboxed arrays.
@@ -62,7 +59,7 @@ deriving instance Show (Name U)
 -------------------------------------------------------------------------------
 -- | Unboxed arrays.
 instance U.Unbox a => Bulk U a where
- data Array U a                 = UArray !(U.Vector a)
+ newtype Array U a              = UArray (U.Vector a)
  layout (UArray vec)            = Unboxed (U.length vec)
  index  (UArray vec) ix         = U.unsafeIndex vec ix
  {-# INLINE_ARRAY layout #-}
@@ -106,12 +103,16 @@ instance U.Unbox a => Windowable U a where
 -------------------------------------------------------------------------------
 -- | Unboxed buffers.
 instance U.Unbox a => Target U a where
- data Buffer U a 
-  = UBuffer !(UM.IOVector a)
+ newtype Buffer s U a
+  = UBuffer (UM.MVector s a)
 
  unsafeNewBuffer (Unboxed len)
   = liftM UBuffer (UM.unsafeNew len)
  {-# INLINE_ARRAY unsafeNewBuffer #-}
+
+ unsafeReadBuffer (UBuffer mvec) ix
+  = UM.unsafeRead mvec ix
+ {-# INLINE_ARRAY unsafeReadBuffer #-}
 
  unsafeWriteBuffer (UBuffer mvec) ix
   = UM.unsafeWrite mvec ix
@@ -122,19 +123,26 @@ instance U.Unbox a => Target U a where
         return  $ UBuffer mvec'
  {-# INLINE_ARRAY unsafeGrowBuffer #-}
 
- unsafeFreezeBuffer (UBuffer mvec)     
+ unsafeFreezeBuffer (UBuffer mvec)
   = do  vec     <- U.unsafeFreeze mvec
         return  $  UArray vec
  {-# INLINE_ARRAY unsafeFreezeBuffer #-}
+
+ unsafeThawBuffer (UArray mvec)
+  = liftM UBuffer (U.unsafeThaw mvec)
+ {-# INLINE_ARRAY unsafeThawBuffer #-}
 
  unsafeSliceBuffer st len (UBuffer mvec)
   = do  let mvec'  = UM.unsafeSlice st len mvec
         return $ UBuffer mvec'
  {-# INLINE_ARRAY unsafeSliceBuffer #-}
 
- touchBuffer _ 
+ touchBuffer _
   = return ()
  {-# INLINE_ARRAY touchBuffer #-}
+
+ bufferLayout (UBuffer mvec)
+   = Unboxed (UM.length mvec)
 
  {-# SPECIALIZE instance Target U Int    #-}
  {-# SPECIALIZE instance Target U Float  #-}
@@ -145,7 +153,7 @@ instance U.Unbox a => Target U a where
  {-# SPECIALIZE instance Target U Word64 #-}
 
 
-instance Unpack (Buffer U a) (UM.IOVector a) where
+instance Unpack (Buffer s U a) (UM.MVector s a) where
  unpack (UBuffer vec)  = vec `seq` vec
  repack !_ !vec        = UBuffer vec
  {-# INLINE_ARRAY unpack #-}

--- a/repa-array/Data/Repa/Array/Tuple.hs
+++ b/repa-array/Data/Repa/Array/Tuple.hs
@@ -16,9 +16,9 @@ import Prelude                          hiding (zip, unzip)
 #include "repa-array.h"
 
 
--- | Tupled arrays where the components are unpacked and can have 
+-- | Tupled arrays where the components are unpacked and can have
 --   separate representations.
-data T2 l1 l2 
+data T2 l1 l2
         = Tup2 l1 l2
 
 
@@ -28,7 +28,7 @@ deriving instance (Show l1, Show l2) => Show (T2 l1 l2)
 
 -------------------------------------------------------------------------------
 instance ( Index  l1 ~ Index l2
-         , Layout l1, Layout l2) 
+         , Layout l1, Layout l2)
         => Layout (T2 l1 l2) where
 
  data Name  (T2 l1 l2)       = T2 (Name l1) (Name l2)
@@ -45,11 +45,11 @@ instance ( Index  l1 ~ Index l2
  {-# INLINE fromIndex #-}
 
 
-deriving instance 
-          (Eq   (Name l1), Eq   (Name l2)) 
+deriving instance
+          (Eq   (Name l1), Eq   (Name l2))
         => Eq   (Name (T2 l1 l2))
 
-deriving instance 
+deriving instance
           (Show (Name l1), Show (Name l2))
         => Show (Name (T2 l1 l2))
 
@@ -68,7 +68,7 @@ instance (Bulk l1 a, Bulk l2 b, Index l1 ~ Index l2)
  {-# INLINE_ARRAY index  #-}
 
 
-deriving instance 
+deriving instance
     (Show (Array l1 a), Show (Array l2 b))
  =>  Show (Array (T2 l1 l2) (a, b))
 
@@ -88,12 +88,18 @@ instance ( Target l1 a, Target l2 b
          , Index l1 ~ Index l2)
       =>   Target (T2 l1 l2) (a, b) where
 
- data Buffer (T2 l1 l2) (a, b) 
-        = T2Buffer !(Buffer l1 a) !(Buffer l2 b)
+ data Buffer s (T2 l1 l2) (a, b)
+        = T2Buffer !(Buffer s l1 a) !(Buffer s l2 b)
 
  unsafeNewBuffer (Tup2 l1 l2)
   = liftM2 T2Buffer (unsafeNewBuffer l1) (unsafeNewBuffer l2)
  {-# INLINE_ARRAY unsafeNewBuffer #-}
+
+ unsafeReadBuffer  (T2Buffer buf1 buf2) ix
+  = do  a <- unsafeReadBuffer buf1 ix
+        b <- unsafeReadBuffer buf2 ix
+        return (a,b)
+ {-# INLINE_ARRAY unsafeReadBuffer #-}
 
  unsafeWriteBuffer  (T2Buffer buf1 buf2) ix (x1, x2)
   = do  unsafeWriteBuffer buf1 ix x1
@@ -112,6 +118,12 @@ instance ( Target l1 a, Target l2 b
         return  $  T2Array arr1 arr2
  {-# INLINE_ARRAY unsafeFreezeBuffer #-}
 
+ unsafeThawBuffer (T2Array arr1 arr2)
+  = do  buf1    <- unsafeThawBuffer arr1
+        buf2    <- unsafeThawBuffer arr2
+        return  $  T2Buffer buf1 buf2
+ {-# INLINE_ARRAY unsafeThawBuffer #-}
+
  unsafeSliceBuffer start len (T2Buffer buf1 buf2)
   = do  buf1'   <- unsafeSliceBuffer start len buf1
         buf2'   <- unsafeSliceBuffer start len buf2
@@ -119,31 +131,33 @@ instance ( Target l1 a, Target l2 b
  {-# INLINE_ARRAY unsafeSliceBuffer #-}
 
  touchBuffer (T2Buffer buf1 buf2)
-  = do  touchBuffer buf1        
+  = do  touchBuffer buf1
         touchBuffer buf2
  {-# INLINE_ARRAY touchBuffer #-}
 
+ bufferLayout (T2Buffer buf1 buf2)
+  = Tup2 (bufferLayout buf1) (bufferLayout buf2)
 
-instance (Unpack (Buffer r1 a) t1, Unpack (Buffer r2 b) t2)
-       => Unpack (Buffer (T2 r1 r2) (a, b)) (t1, t2) where
- unpack  (T2Buffer buf1 buf2) 
+instance (Unpack (Buffer s r1 a) t1, Unpack (Buffer s r2 b) t2)
+       => Unpack (Buffer s (T2 r1 r2) (a, b)) (t1, t2) where
+ unpack  (T2Buffer buf1 buf2)
    = buf1 `seq` buf2 `seq` (unpack buf1, unpack buf2)
  {-# INLINE_ARRAY unpack #-}
 
- repack !(T2Buffer x1 x2) (buf1, buf2)      
+ repack !(T2Buffer x1 x2) (buf1, buf2)
    = buf1 `seq` buf2 `seq` (T2Buffer (repack x1 buf1) (repack x2 buf2))
  {-# INLINE_ARRAY repack #-}
 
 
 -------------------------------------------------------------------------------
 -- | Tuple two arrays into an array of pairs.
--- 
+--
 --   The two argument arrays must have the same index type, but can have
 --   different extents. The extent of the result is the intersection
 --   of the extents of the two argument arrays.
 --
 tup2    :: (Bulk l1 a, Bulk l2 b, Index l1 ~ Index l2)
-        => Array l1 a -> Array l2 b 
+        => Array l1 a -> Array l2 b
         -> Array (T2 l1 l2) (a, b)
 tup2 arr1 arr2
         = T2Array arr1 arr2

--- a/repa-array/Data/Repa/Eval/Chain.hs
+++ b/repa-array/Data/Repa/Eval/Chain.hs
@@ -32,7 +32,7 @@ chainOfArray !arr
 
         step !i
          | i >= len     = return $ Done  i
-         | otherwise    
+         | otherwise
          = return $ Yield (A.index arr $ A.fromIndex (A.layout arr) i) (i + 1)
         {-# INLINE_INNER step #-}
 {-# INLINE_STREAM chainOfArray #-}
@@ -49,25 +49,25 @@ liftChain (Chain sz s step)
 -- | Compute the elements of a pure `Chain`,
 --   writing them into a new array `Array`.
 unchainToArray
-        :: (Target l a, Unpack (Buffer l a) t)
+        :: (Target l a, Unpack (IOBuffer l a) t)
         => Name l -> Chain S.Id s a -> (Array l a, s)
 unchainToArray nDst c
-        = unsafePerformIO 
+        = unsafePerformIO
         $ unchainToArrayIO nDst
         $ liftChain c
 {-# INLINE_STREAM unchainToArray #-}
 
 
--- | Compute the elements of an `IO` `Chain`, 
+-- | Compute the elements of an `IO` `Chain`,
 --   writing them to a new `Array`.
 unchainToArrayIO
-        :: (Target l a, Unpack (Buffer l a) t)
+        :: (Target l a, Unpack (IOBuffer l a) t)
         => Name l -> Chain IO s a -> IO (Array l a, s)
 
 unchainToArrayIO nDst (Chain sz s0 step)
  = case sz of
-        S.Exact i       -> unchainToArrayIO_max     i 
-        S.Max i         -> unchainToArrayIO_max     i 
+        S.Exact i       -> unchainToArrayIO_max     i
+        S.Max i         -> unchainToArrayIO_max     i
         S.Unknown       -> unchainToArrayIO_unknown 32
 
         -- unchain when we known the maximum size of the vector.
@@ -78,14 +78,14 @@ unchainToArrayIO nDst (Chain sz s0 step)
                 let go_unchainIO_max !sPEC !i !s
                      =  step s >>= \m
                      -> case m of
-                         Yield e s'    
+                         Yield e s'
                           -> do  unsafeWriteBuffer vec i e
                                  go_unchainIO_max sPEC (i + 1) s'
-        
-                         Skip s' 
+
+                         Skip s'
                           ->     go_unchainIO_max sPEC i s'
-        
-                         Done s' 
+
+                         Done s'
                           -> do  buf'    <- unsafeSliceBuffer  0 i vec
                                  arr     <- unsafeFreezeBuffer buf'
                                  return  (arr, s')
@@ -108,19 +108,19 @@ unchainToArrayIO nDst (Chain sz s0 step)
                      =  step s >>= \r
                      -> case r of
                          Yield e s'
-                          -> do (vec', n') 
-                                 <- if i >= n 
+                          -> do (vec', n')
+                                 <- if i >= n
                                         then do vec' <- unsafeGrowBuffer vec n
                                                 return (vec', n + n)
                                         else    return (vec,  n)
                                 unsafeWriteBuffer vec' i e
                                 cont vec' (i + 1) n' s'
 
-                         Skip s' 
+                         Skip s'
                           ->    cont vec i n s'
 
-                         Done s' 
-                          -> do 
+                         Done s'
+                          -> do
                                 vec' <- unsafeSliceBuffer  0 i vec
                                 arr  <- unsafeFreezeBuffer vec'
                                 done (arr, s')
@@ -133,19 +133,19 @@ unchainToArrayIO nDst (Chain sz s0 step)
 
 {-
         -- This consuming function has been desugared so that the recursion
-        -- is via RealWorld, rather than using a function of type IO. 
+        -- is via RealWorld, rather than using a function of type IO.
         -- If the recursion is at IO then GHC tries to coerce to and from
         -- IO at every recursive call, which messes up SpecConstr.
-          let go_unchainIO_unknown 
+          let go_unchainIO_unknown
              :: Unpack (Buffer r a) t
-             => S.SPEC -> t -> Int -> Int -> s 
+             => S.SPEC -> t -> Int -> Int -> s
              -> State# RealWorld -> (# State# RealWorld, (Array r DIM1 a, s) #)
 
               go_unchainIO_unknown !sPEC !uvec !i !n !s !w0
                = case unIO (step s) w0 of
                   (# w1, Yield e s' #)
                    | (# w2,  (uvec', i', n') #)
-                     <- unIO (do (vec', n') 
+                     <- unIO (do (vec', n')
                                   <- if i >= n
                                       then do vec' <- unsafeGrowBuffer (repack vec0 uvec) n
                                               return (vec', n + n)
@@ -157,7 +157,7 @@ unchainToArrayIO nDst (Chain sz s0 step)
 
                  (# w1, Skip s' #)
                   -> (go_unchainIO_unknown sPEC uvec  i  n  s') w1
-    
+
                  (# w1, Done s' #)
                   -> (unIO $ do
                        vec' <- unsafeSliceBuffer 0 i (repack vec0 uvec)

--- a/repa-array/Data/Repa/IO/Array.hs
+++ b/repa-array/Data/Repa/IO/Array.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ViewPatterns #-}
 
 module Data.Repa.IO.Array
         ( hGetArray,   hGetArrayPre
@@ -13,7 +14,7 @@ import Data.Word
 
 
 -- | Get data from a file, up to the given number of bytes.
--- 
+--
 --   * Data is read into foreign memory without copying it through the GHC heap.
 --
 hGetArray :: Handle -> Int -> IO (Array F Word8)
@@ -26,15 +27,15 @@ hGetArray h len
 {-# NOINLINE hGetArray #-}
 
 
--- | Get data from a file, up to the given number of bytes, also 
+-- | Get data from a file, up to the given number of bytes, also
 --   copying the given data to the front of the new buffer.
 --
 --   * Data is read into foreign memory without copying it through the GHC heap.
 --
 hGetArrayPre :: Handle -> Int -> Array F Word8 -> IO (Array F Word8)
-hGetArrayPre h len (FArray offset lenPre fptrPre)
+hGetArrayPre h len (toForeignPtr -> (offset,lenPre,fptrPre))
  = F.withForeignPtr fptrPre
- $ \ptrPre' -> do   
+ $ \ptrPre' -> do
         let ptrPre      = F.plusPtr ptrPre' offset
         ptrBuf :: F.Ptr Word8 <- F.mallocBytes (lenPre + len)
         F.copyBytes ptrBuf ptrPre lenPre
@@ -51,7 +52,7 @@ hGetArrayPre h len (FArray offset lenPre fptrPre)
 --     without copying it through the GHC heap.
 --
 hPutArray :: Handle -> Array F Word8 -> IO ()
-hPutArray h (FArray offset lenPre fptr)
+hPutArray h (toForeignPtr -> (offset,lenPre,fptr))
  = F.withForeignPtr fptr
  $ \ptr' -> do
         let ptr         = F.plusPtr ptr' offset


### PR DESCRIPTION
I thought it would be nice if repa had a way of working with mutable arrays so I cooked this up. I noticed you're working on a new version so this is just an idea of how you might do it.

The main idea is to generalise from `IO` to `PrimMonad` and add `read`, `thaw` and `layout` functions to the `Target` class. For now `Load` it just uses an `IOBuffer = Buffer RealWorld` but you should be able to generalise to `Buffer`.

I also switched to `vector`'s storable vector for foreign arrays since the implementations are pretty much the same.

Let me know what you think :)