### PR TITLE
Bump `vector` upper bounds

### DIFF
--- a/repa-algorithms/repa-algorithms.cabal
+++ b/repa-algorithms/repa-algorithms.cabal
@@ -19,7 +19,7 @@ Synopsis:
 Library
   Build-Depends:
         base                 >= 4.8 && < 4.10
-      , vector               == 0.11.*
+      , vector               >= 0.11 && < 0.13
       , repa                 == 3.4.1.*
 
   ghc-options:

--- a/repa-algorithms/repa-algorithms.cabal
+++ b/repa-algorithms/repa-algorithms.cabal
@@ -1,5 +1,5 @@
 Name:                repa-algorithms
-Version:             3.4.1.1
+Version:             3.4.1.2
 License:             BSD3
 License-file:        LICENSE
 Author:              The DPH Team

--- a/repa-examples/repa-examples.cabal
+++ b/repa-examples/repa-examples.cabal
@@ -157,7 +157,7 @@ Executable repa-blur
         base                 >= 4.8 && < 4.10
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
-      , vector               == 0.11.*
+      , vector               >= 0.11 && < 0.13
 
   Main-is: examples/Blur/src-repa/Main.hs
   hs-source-dirs: examples/Blur/src-repa .
@@ -234,4 +234,3 @@ Executable repa-unit-test
  if flag(llvm)
   ghc-options:
         -fllvm -optlo-O3
-

--- a/repa-examples/repa-examples.cabal
+++ b/repa-examples/repa-examples.cabal
@@ -1,5 +1,5 @@
 Name:                repa-examples
-Version:             3.4.1.1
+Version:             3.4.1.2
 License:             BSD3
 License-file:        LICENSE
 Author:              The DPH Team

--- a/repa-io/repa-io.cabal
+++ b/repa-io/repa-io.cabal
@@ -1,5 +1,5 @@
 Name:                repa-io
-Version:             3.4.1.1
+Version:             3.4.1.2
 License:             BSD3
 License-file:        LICENSE
 Author:              The DPH Team

--- a/repa-io/repa-io.cabal
+++ b/repa-io/repa-io.cabal
@@ -24,7 +24,7 @@ Library
       , bytestring           == 0.10.*
       , old-time             == 1.1.*
       , repa                 == 3.4.*
-      , vector               == 0.11.*
+      , vector               >= 0.11 && < 0.13
 
   ghc-options:
         -O2 -Wall -fno-warn-missing-signatures

--- a/repa/repa.cabal
+++ b/repa/repa.cabal
@@ -1,5 +1,5 @@
 Name:                repa
-Version:             3.4.1.2
+Version:             3.4.1.3
 License:             BSD3
 License-file:        LICENSE
 Author:              The DPH Team

--- a/repa/repa.cabal
+++ b/repa/repa.cabal
@@ -24,7 +24,7 @@ Library
         base                 >= 4.8 && < 4.10
       , template-haskell
       , ghc-prim
-      , vector               == 0.11.*
+      , vector               >= 0.11 && < 0.13
       , bytestring           == 0.10.*
       , QuickCheck           >= 2.8 && < 2.10
 
@@ -94,4 +94,3 @@ Library
         Data.Array.Repa.Stencil.Template
         Data.Array.Repa.Stencil.Partition
         Data.Array.Repa.Base
-        

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,8 +10,7 @@ packages:
 - 'repa-examples'
 
 # Packages to be pulled from upstream that are not in the resolver
-extra-deps:
-  - bmp-1.2.6.3
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 # vim: nospell
 
-resolver: nightly-2016-09-01
+resolver: lts-7.15
 
 packages:
 - 'repa'


### PR DESCRIPTION
These compile fine when `vector-0.12` is forced. The unit tests in `repa-examples` don't pass as-is though, throwing some odd QuickCheck exceptions.